### PR TITLE
fix default admin ns filter is invalid

### DIFF
--- a/shell/components/nav/NamespaceFilter.vue
+++ b/shell/components/nav/NamespaceFilter.vue
@@ -663,6 +663,11 @@ export default {
       const user = this.$store.getters['auth/user'];
 
       if (user && user.status?.isAdmin) {
+        this.$store.dispatch('prefs/set', {
+          key:   NAMESPACE_FILTERS,
+          value: { local: [] }
+        });
+
         return [];
       }
 


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes default admin ns filter is not set correctly to all namespaces.