### PR TITLE
fix: update ray default svc and api_url

### DIFF
--- a/shell/models/ml_workload.js
+++ b/shell/models/ml_workload.js
@@ -23,17 +23,19 @@ export default class MlWorkload extends MLWorkloadService {
 
     if (type !== ML_WORKLOAD_TYPES.RAY_CLUSTER) {
       insertAt(out, 1, {
-        action:  'pause',
-        label:   this.t('asyncButton.pause.action'),
-        icon:    'icon icon-pause',
-        enabled: !!this.links.update && !this.isPaused
+        action:   'pause',
+        label:    this.t('asyncButton.pause.action'),
+        icon:     'icon icon-pause',
+        enabled:  !!this.links.update && !this.isPaused,
+        bulkable: true,
       });
 
       insertAt(out, 1, {
-        action:  'resume',
-        label:   this.t('asyncButton.resume.action'),
-        icon:    'icon icon-play',
-        enabled: !!this.links.update && this.isPaused
+        action:   'resume',
+        label:    this.t('asyncButton.resume.action'),
+        icon:     'icon icon-play',
+        enabled:  !!this.links.update && this.isPaused,
+        bulkable: true,
       });
     }
 

--- a/shell/models/ml_workload.service.js
+++ b/shell/models/ml_workload.service.js
@@ -3,7 +3,7 @@ import SteveModel from '@shell/plugins/steve/steve-class';
 import { SETTING } from '@shell/config/settings';
 
 export const TYPE_TO_SVC_PORT_NAME_MAPPING = {
-  [ML_WORKLOAD_TYPES.RAY_CLUSTER]:   'dashboard',
+  [ML_WORKLOAD_TYPES.RAY_CLUSTER]:   'client',
   [ML_WORKLOAD_TYPES.NOTEBOOK]:      'http',
   [ML_WORKLOAD_TYPES.MODEL_SERVICE]: 'http',
 };
@@ -33,12 +33,13 @@ export default class MLWorkloadService extends SteveModel {
     const url = new URL(serverURL);
     const portName = TYPE_TO_SVC_PORT_NAME_MAPPING[this.type];
     const port = svc.spec.ports.find((p) => p.name === portName);
+    const protocol = this.type === ML_WORKLOAD_TYPES.RAY_CLUSTER ? 'ray' : 'http';
 
     switch (svc.spec.type) {
     case 'NodePort':
-      return `http://${ url.hostname }:${ port.nodePort }`;
+      return `${ protocol }://${ url.hostname }:${ port.nodePort }`;
     case 'LoadBalancer':
-      return `http://${ url.hostname }:${ port.port }`;
+      return `${ protocol }://${ url.hostname }:${ port.port }`;
     default:
       return `${ window.location.origin }/api/v1/namespaces/${ svc.metadata.namespace }/services/${ svc.metadata.name }:${ port.name }/proxy`;
     }

--- a/shell/models/ray.io.raycluster.js
+++ b/shell/models/ray.io.raycluster.js
@@ -30,6 +30,7 @@ export default class RayCluster extends MlWorkload {
         },
         enableInTreeAutoscaling: true,
         headGroupSpec:           {
+          serviceType:    'NodePort',
           rayStartParams: {
             'num-cpus':       '0',
             'redis-password': '$REDIS_PASSWORD'


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
- Update ray default svc type and api_url
- Add ML workload bulk start/pause action


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enabled bulk execution for pause and resume actions, allowing multiple actions to be processed simultaneously.
  - Improved service connectivity by dynamically adjusting the protocol in endpoint URLs based on the workload type.
  - Added explicit service type settings for cluster head configurations, enhancing the overall cluster connectivity and management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->