### PR TITLE
Check CAN_YAML pref before showing yaml editor

### DIFF
--- a/shell/components/CruResource.vue
+++ b/shell/components/CruResource.vue
@@ -9,6 +9,7 @@ import AsyncButton from '@shell/components/AsyncButton';
 import { mapGetters, mapState, mapActions } from 'vuex';
 import { stringify, exceptionToErrorsArray } from '@shell/utils/error';
 import CruResourceFooter from '@shell/components/CruResourceFooter';
+import { CAN_YAML } from '@shell/store/prefs';
 
 import {
   _EDIT,
@@ -231,7 +232,8 @@ export default {
         this.canYaml &&
         (this._selectedSubtype || !this.subtypes.length) &&
         this.canEditYaml &&
-        this.mode !== _VIEW
+        this.mode !== _VIEW &&
+        this.$store.getters['prefs/get'](CAN_YAML)
       );
     },
 

--- a/shell/detail/ml.llmos.ai.model/FileList/useFileList.js
+++ b/shell/detail/ml.llmos.ai.model/FileList/useFileList.js
@@ -87,15 +87,13 @@ export const useFileList = ({ props = {}, emit }) => {
 
     const { file } = options;
 
-    const destPath = currentPath.value ? 
-      `${prefixPath}/${currentPath.value}/${file.name}` :
-      `${prefixPath}/${file.name}`
+    const destPath = currentPath.value ? `${ prefixPath }/${ currentPath.value }/${ file.name }` : `${ prefixPath }/${ file.name }`;
 
     const fileInfo = {
       destPath,
-      fileName: file.name,
-      size: file.size,
-      readSize: 0,
+      fileName:  file.name,
+      size:      file.size,
+      readSize:  0,
       totalSize: 100,
     };
 

--- a/shell/detail/ml.llmos.ai.model/FileList/useFileList.js
+++ b/shell/detail/ml.llmos.ai.model/FileList/useFileList.js
@@ -15,6 +15,9 @@ export const useFileList = ({ props = {}, emit }) => {
   const currentPath = ref('');
   // const maxConcurrent = ref(1);
 
+  const prefixPath =
+    props.resource.status.rootPath || props.resource.status.path;
+
   const uploadFile = (formData) => {
     return new Promise((resolve, reject) => {
       const processUpload = async() => {
@@ -83,6 +86,20 @@ export const useFileList = ({ props = {}, emit }) => {
     showModal.value = true;
 
     const { file } = options;
+
+    const destPath = currentPath.value ? 
+      `${prefixPath}/${currentPath.value}/${file.name}` :
+      `${prefixPath}/${file.name}`
+
+    const fileInfo = {
+      destPath,
+      fileName: file.name,
+      size: file.size,
+      readSize: 0,
+      totalSize: 100,
+    };
+
+    fileList.value.unshift(fileInfo);
 
     try {
       uploading.value = true;

--- a/shell/models/agent.llmos.ai.datacollection.js
+++ b/shell/models/agent.llmos.ai.datacollection.js
@@ -1,5 +1,6 @@
 import SteveModel from '@shell/plugins/steve/steve-class';
 import { set } from '@shell/utils/object';
+import { LLMOS } from '@shell/config/types';
 
 export default class Dataset extends SteveModel {
   applyDefaults() {
@@ -10,7 +11,7 @@ export default class Dataset extends SteveModel {
         labels:      {},
         annotations: {},
       },
-      spec: { registry: this.t('modelRegistry.useDefault') },
+      spec: { registry: this.hasDefaultRegistry ? this.t('modelRegistry.useDefault') : '' },
     };
 
     this.metadata = value.metadata;
@@ -19,5 +20,12 @@ export default class Dataset extends SteveModel {
 
   get documentCount() {
     return (this.status?.files || []).length;
+  }
+
+  get hasDefaultRegistry() {
+    const registries = this.$getters['all'](LLMOS.REGISTRY);
+    const out = (registries || []).find((registry) => registry.isDefault);
+
+    return out?.id;
   }
 }

--- a/shell/models/ml.llmos.ai.dataset.js
+++ b/shell/models/ml.llmos.ai.dataset.js
@@ -13,7 +13,7 @@ export default class Dataset extends SteveModel {
       },
       spec: {
         datasetCard: { metadata: { splitTypes: [] } },
-        registry:    this.t('modelRegistry.useDefault'),
+        registry:    this.hasDefaultRegistry ? this.t('modelRegistry.useDefault') : '',
       },
     };
 
@@ -79,5 +79,12 @@ export default class Dataset extends SteveModel {
 
   get latestDatasetVersion() {
     return this.datasetVersions?.[0] || {};
+  }
+
+  get hasDefaultRegistry() {
+    const registries = this.$getters['all'](LLMOS.REGISTRY);
+    const out = (registries || []).find((registry) => registry.isDefault);
+
+    return out?.id;
   }
 }

--- a/shell/models/ml.llmos.ai.model.js
+++ b/shell/models/ml.llmos.ai.model.js
@@ -18,7 +18,7 @@ export default class ModelRegistry extends SteveModel {
       },
       spec: {
         modelCard: { metadata: {} },
-        registry:  this.t('modelRegistry.useDefault'),
+        registry:  this.hasDefaultRegistry ? this.t('modelRegistry.useDefault') : '',
       },
     };
 
@@ -127,5 +127,12 @@ export default class ModelRegistry extends SteveModel {
     } catch (err) {
       message.error(`${ err.message || err }`);
     }
+  }
+
+  get hasDefaultRegistry() {
+    const registries = this.$getters['all'](LLMOS_TYPES.REGISTRY);
+    const out = (registries || []).find((registry) => registry.isDefault);
+
+    return out?.id;
   }
 }


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes 
- Add destPath calculation and fileInfo object creation to track upload progress
- Ensure the YAML editor is only shown when the CAN_YAML preference is enabled
- Add hasDefaultRegistry getter to check for default registry presence

<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->