### PR TITLE
fix: set default useSSL to true for s3Config

### DIFF
--- a/shell/edit/ml.llmos.ai.registry.vue
+++ b/shell/edit/ml.llmos.ai.registry.vue
@@ -56,7 +56,7 @@ export default {
         endpoint:                   this.value.spec?.s3Config?.endpoint || '',
         bucket:                     this.value.spec?.s3Config?.bucket || '',
         accessCredentialSecretName: this.value.spec?.s3Config?.accessCredentialSecretName || '',
-        useSSL:                     this.value.spec?.s3Config?.useSSL || false,
+        useSSL:                     this.value.spec?.s3Config?.useSSL ?? true,
       },
     };
 

--- a/shell/models/ml.llmos.ai.registry.js
+++ b/shell/models/ml.llmos.ai.registry.js
@@ -18,7 +18,7 @@ export default class ModelRegistry extends SteveModel {
           endpoint:                   '',
           bucket:                     '',
           accessCredentialSecretName: '',
-          useSSL:                     false,
+          useSSL:                     true,
         },
       },
     };


### PR DESCRIPTION


<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Prevent potential security issues by defaulting to secure connections
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated the default setting for the S3 backend to use SSL, ensuring secure connections by default in the configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->